### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate Models - using litellm

### DIFF
--- a/prompterator/models/openai_models.py
+++ b/prompterator/models/openai_models.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import openai
+from litellm import completion
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class ChatGPTMixin(PrompteratorLLM):
     def call(self, idx, input, **kwargs):
         model_params = kwargs["model_params"]
         try:
-            response_data = openai.ChatCompletion.create(
+            response_data = completion(
                 model=self.properties.name, messages=input, **model_params
             )
             response_text = [choice["message"]["content"] for choice in response_data["choices"]][

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "prompterator"}]
 python = "^3.10"
 pydantic = "^1.10.7"
 openai = "^0.27.6"
+litellm = "^0.1.400"
 streamlit = "^1.22.0"
 streamlit-toggle-switch = "^1.0.2"
 diff-match-patch = "^20230430"


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
