### PR TITLE
Suggest Prompt Improvements feature (idea from Singapore)

### DIFF
--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -604,13 +604,15 @@ def show_suggestions():
 
     max_tokens = 4000
     model_name = "gpt-4"  # Specific only for this one feature
+    min_labeled_data = 0.8
 
-    if "n_checked" not in st.session_state:
+    if "n_checked" not in st.session_state:  # To get rid of the initial warning
         st.session_state.n_checked = 0
 
     # Only show the suggestions if the user labeled somehow at least 80% of the data and if
     # there is at least one Bad label
-    if (st.session_state.n_checked / len(st.session_state.df) >= 0.8) and (c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values):
+    if ((st.session_state.n_checked / len(st.session_state.df) >= min_labeled_data)
+            and (c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values)):
         content = st.session_state.df.to_dict(orient="records")
         prompt = st.session_state.system_prompt
 

--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -596,6 +596,46 @@ def process_uploaded_file():
         initialise_session_from_uploaded_file(df)
 
 
+def show_suggestions():
+    """Collect the prompt, together with the results from the labeling (text, response,
+    and human_label columns) to send a request to OpenAI to suggest improvements of the original
+    prompt.
+    """
+
+    max_tokens = 4000
+    model_name = "gpt-4"
+
+    if "n_checked" not in st.session_state:
+        st.session_state.n_checked = 0
+
+    # Only show the suggestions if the user labeled somehow at least 80% of the data and if
+    # there is at least one Bad label
+    if (st.session_state.n_checked / len(st.session_state.df) >= 0.8) and (c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values):
+        content = st.session_state.df.to_dict(orient="records")
+
+        content_with_label_good = [f"Original: {text[c.TEXT_ORIG_COL]}\nGenerated: {text[c.TEXT_GENERATED_COL]}\nLabel: {text[c.LABEL_COL]}" for text in content if text[c.LABEL_COL] == c.LABEL_GOOD]
+        content_with_label_bad = [f"Original: {text[c.TEXT_ORIG_COL]}\nGenerated: {text[c.TEXT_GENERATED_COL]}\nLabel: {text[c.LABEL_COL]}" for text in content if text[c.LABEL_COL] == c.LABEL_BAD]
+
+        prompt = st.session_state.system_prompt
+
+        mixed_content = u.mix_content(content_with_label_bad, content_with_label_good, max_tokens)
+        format_mixed_content = u.format_mixed_content(mixed_content)
+
+        system_prompt = (f"Here is a dataset of texts, responses, and human labels (first the "
+                         f"ones labeled as Bad, then the ones lab"
+                         f"eled as Good): \n\n{format_mixed_content}\n\nHere is the Prompt that "
+                         f"led to the generated responses: '{prompt}'\n\nPlease suggest "
+                         f"improvements to the Prompt above.")
+        user_prompt = ("Follow the system prompt and only output suggestions on how to improve "
+                       "the prompt.")
+
+        with st.spinner("Generating suggestions..."):
+            model_suggestion = u.predict(system_prompt, user_prompt, model_name, max_tokens)
+
+        with st.expander(f"Suggested prompt improvements by {model_name.upper()}"):
+            st.write(f'{model_name.upper()}: {model_suggestion}')
+
+
 # Add the logo and bring the padding down (we've got the title in the logo anyway)
 st.markdown(
     """
@@ -633,3 +673,4 @@ if st.session_state.get("enable_labelling", False):
 
 show_col_selection()
 show_dataframe()
+show_suggestions()

--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -603,7 +603,7 @@ def show_suggestions():
     """
 
     max_tokens = 4000
-    model_name = "gpt-4"
+    model_name = "gpt-4"  # Specific only for this one feature
 
     if "n_checked" not in st.session_state:
         st.session_state.n_checked = 0
@@ -612,20 +612,31 @@ def show_suggestions():
     # there is at least one Bad label
     if (st.session_state.n_checked / len(st.session_state.df) >= 0.8) and (c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values):
         content = st.session_state.df.to_dict(orient="records")
-
-        content_with_label_good = [f"Original: {text[c.TEXT_ORIG_COL]}\nGenerated: {text[c.TEXT_GENERATED_COL]}\nLabel: {text[c.LABEL_COL]}" for text in content if text[c.LABEL_COL] == c.LABEL_GOOD]
-        content_with_label_bad = [f"Original: {text[c.TEXT_ORIG_COL]}\nGenerated: {text[c.TEXT_GENERATED_COL]}\nLabel: {text[c.LABEL_COL]}" for text in content if text[c.LABEL_COL] == c.LABEL_BAD]
-
         prompt = st.session_state.system_prompt
+
+        content_with_label_good = [
+            (f"Original: {text[c.TEXT_ORIG_COL]}\n"
+             f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
+             f"Label: {text[c.LABEL_COL]}")
+            for text in content if text[c.LABEL_COL] == c.LABEL_GOOD
+        ]
+
+        content_with_label_bad = [
+            (f"Original: {text[c.TEXT_ORIG_COL]}\n"
+             f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
+             f"Label: {text[c.LABEL_COL]}")
+            for text in content if text[c.LABEL_COL] == c.LABEL_BAD
+        ]
 
         mixed_content = u.mix_content(content_with_label_bad, content_with_label_good, max_tokens)
         format_mixed_content = u.format_mixed_content(mixed_content)
 
         system_prompt = (f"Here is a dataset of texts, responses, and human labels (first the "
-                         f"ones labeled as Bad, then the ones lab"
-                         f"eled as Good): \n\n{format_mixed_content}\n\nHere is the Prompt that "
+                         f"ones labeled as Bad, then the ones labeled as Good):"
+                         f"\n\n{format_mixed_content}\n\nHere is the Prompt that "
                          f"led to the generated responses: '{prompt}'\n\nPlease suggest "
                          f"improvements to the Prompt above.")
+
         user_prompt = ("Follow the system prompt and only output suggestions on how to improve "
                        "the prompt.")
 

--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -611,42 +611,52 @@ def show_suggestions():
 
     # Only show the suggestions if the user labeled somehow at least 80% of the data and if
     # there is at least one Bad label
-    if ((st.session_state.n_checked / len(st.session_state.df) >= min_labeled_data)
-            and (c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values)):
+    if (st.session_state.n_checked / len(st.session_state.df) >= min_labeled_data) and (
+        c.LABEL_BAD in st.session_state.df[c.LABEL_COL].values
+    ):
         content = st.session_state.df.to_dict(orient="records")
         prompt = st.session_state.system_prompt
 
         content_with_label_good = [
-            (f"Original: {text[c.TEXT_ORIG_COL]}\n"
-             f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
-             f"Label: {text[c.LABEL_COL]}")
-            for text in content if text[c.LABEL_COL] == c.LABEL_GOOD
+            (
+                f"Original: {text[c.TEXT_ORIG_COL]}\n"
+                f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
+                f"Label: {text[c.LABEL_COL]}"
+            )
+            for text in content
+            if text[c.LABEL_COL] == c.LABEL_GOOD
         ]
 
         content_with_label_bad = [
-            (f"Original: {text[c.TEXT_ORIG_COL]}\n"
-             f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
-             f"Label: {text[c.LABEL_COL]}")
-            for text in content if text[c.LABEL_COL] == c.LABEL_BAD
+            (
+                f"Original: {text[c.TEXT_ORIG_COL]}\n"
+                f"Generated: {text[c.TEXT_GENERATED_COL]}\n"
+                f"Label: {text[c.LABEL_COL]}"
+            )
+            for text in content
+            if text[c.LABEL_COL] == c.LABEL_BAD
         ]
 
         mixed_content = u.mix_content(content_with_label_bad, content_with_label_good, max_tokens)
         format_mixed_content = u.format_mixed_content(mixed_content)
 
-        system_prompt = (f"Here is a dataset of texts, responses, and human labels (first the "
-                         f"ones labeled as Bad, then the ones labeled as Good):"
-                         f"\n\n{format_mixed_content}\n\nHere is the Prompt that "
-                         f"led to the generated responses: '{prompt}'\n\nPlease suggest "
-                         f"improvements to the Prompt above.")
+        system_prompt = (
+            f"Here is a dataset of texts, responses, and human labels (first the "
+            f"ones labeled as Bad, then the ones labeled as Good):"
+            f"\n\n{format_mixed_content}\n\nHere is the Prompt that "
+            f"led to the generated responses: '{prompt}'\n\nPlease suggest "
+            f"improvements to the Prompt above."
+        )
 
-        user_prompt = ("Follow the system prompt and only output suggestions on how to improve "
-                       "the prompt.")
+        user_prompt = (
+            "Follow the system prompt and only output suggestions on how to improve " "the prompt."
+        )
 
         with st.spinner("Generating suggestions..."):
             model_suggestion = u.predict(system_prompt, user_prompt, model_name, max_tokens)
 
         with st.expander(f"Suggested prompt improvements by {model_name.upper()}"):
-            st.write(f'{model_name.upper()}: {model_suggestion}')
+            st.write(f"{model_name.upper()}: {model_suggestion}")
 
 
 # Add the logo and bring the padding down (we've got the title in the logo anyway)

--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -649,7 +649,7 @@ def show_suggestions():
         )
 
         user_prompt = (
-            "Follow the system prompt and only output suggestions on how to improve " "the prompt."
+            "Follow the system prompt and only output suggestions on how to improve the prompt."
         )
 
         with st.spinner("Generating suggestions..."):

--- a/prompterator/utils.py
+++ b/prompterator/utils.py
@@ -311,3 +311,56 @@ def insert_hidden_html_marker(helper_element_id, target_streamlit_element=None):
         """,
         unsafe_allow_html=True,
     )
+
+
+def mix_content(content_bad, content_good, max_tokens):
+    """This function mixes content labeled as 'Bad' and 'Good' based on a specified ratio and
+    token limits (this is to fit the right data points into the prompt).
+
+    :param content_bad: List of strings where each string is a "Bad" labeled content piece.
+    :param content_good: List of strings where each string is a "Good" labeled content piece.
+    :param max_tokens: Maximum number of tokens (words) to include in the mixed content.
+    :return: A mixed list of content with the specified ratio, not exceeding max_tokens.
+    """
+    max_tokens_bad = int(max_tokens * 0.8)  # We want 80% of the tokens to be Bad content
+    mixed_content = []
+    current_tokens = 0
+
+    def count_tokens(s):  # This is a quick replacement for real tokenization
+        return len(s) // 5  # One token is approximately 5 characters
+
+    for item in content_bad:
+        item_tokens = count_tokens(item)
+        if current_tokens + item_tokens <= max_tokens_bad:
+            mixed_content.append(item)
+            current_tokens += item_tokens
+        else:
+            break  # Stop adding more Bad content if we reach the limit
+
+    for item in content_good:
+        item_tokens = count_tokens(item)
+        if current_tokens + item_tokens <= max_tokens:
+            mixed_content.append(item)
+            current_tokens += item_tokens
+        else:
+            break  # Stop adding more Good content if we reach the overall max_tokens limit
+
+    return mixed_content
+
+
+def format_mixed_content(mixed_content):
+    return "\n\n".join(mixed_content)
+
+
+def predict(system_prompt, user_prompt, model_name, max_tokens):
+    """Very simple function to call OpenAI's ChatCompletion API."""
+    response = openai.ChatCompletion.create(
+        model=model_name,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ],
+        max_tokens=max_tokens,
+        temperature=0.8
+    )
+    return response['choices'][0]['message']['content']

--- a/prompterator/utils.py
+++ b/prompterator/utils.py
@@ -358,9 +358,9 @@ def predict(system_prompt, user_prompt, model_name, max_tokens):
         model=model_name,
         messages=[
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
+            {"role": "user", "content": user_prompt},
         ],
         max_tokens=max_tokens,
-        temperature=0.8
+        temperature=0.8,
     )
-    return response['choices'][0]['message']['content']
+    return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
As many suggested at the EMNLP conference, it would be "cool" if prompterator could also generate prompt suggestions from the labeled data. Well, now, its closer to reality:

After the user labels some data (80%), the `Suggest Prompt Improvements` feature kicks in and sends a request to OpenAI with the labeled dataset and original prompt, prompting it to give suggestions for improvements (focusing on the `Bad` examples).

Apologies for the hardcoded constants and low code quality; if we want, we can turn this into a proper feature of production quality but for now I kept it as a fun, weekend project.

<img width="1252" alt="Screenshot 2024-02-11 at 14 02 29" src="https://github.com/slidoapp/prompterator/assets/17952892/23a362b4-9d10-45e5-9720-9a76803f18cd">
<img width="495" alt="Screenshot 2024-02-11 at 14 02 20" src="https://github.com/slidoapp/prompterator/assets/17952892/9d87ecaa-3ee5-4906-a4c8-287a173b02e9">

