### PR TITLE
fix: change datafiles naming pattern

### DIFF
--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -374,9 +374,13 @@ def set_up_ui_saved_datafiles():
 
                     # prettify the timestamp
                     input_timestamp = metadata[c.TIMESTAMP_COL]
-                    input_format = "%m-%d-%y_%H:%M:%S"
+                    input_format = "%Y-%m-%d-%H-%M-%S"
+                    fallback_input_format = "%m-%d-%y_%H:%M:%S"
                     output_format = "%I:%M %p — %b %d, %Y"
-                    timestamp = datetime.strptime(input_timestamp, input_format)
+                    try:
+                        timestamp = datetime.strptime(input_timestamp, input_format)
+                    except ValueError:
+                        timestamp = datetime.strptime(input_timestamp, fallback_input_format)
 
                     st.markdown(
                         f"""

--- a/prompterator/utils.py
+++ b/prompterator/utils.py
@@ -218,7 +218,7 @@ def get_correctness_summary(df):
 
 
 def save_labelled_data():
-    ts = datetime.now().strftime("%-m-%-d-%y_%-H:%M:%S")
+    ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     file_name = f"{c.DATA_STORE_DIR}/{ts}.json"
     model = st.session_state[c.MODEL_KEY]
     configurable_params = {name: st.session_state[name] for name in model.configurable_params}


### PR DESCRIPTION
Datafiles created with the old pattern had the following drawbacks:

- They were not sorted in any meaningful way in the file tree.
- They contained ":" which are considered invalid characters on Windows.
