### PR TITLE
fix: parse nulls when loading CSV

### DIFF
--- a/prompterator/main.py
+++ b/prompterator/main.py
@@ -844,6 +844,7 @@ def show_dataframe():
 def process_uploaded_file():
     if st.session_state.uploaded_file is not None:
         df = pd.read_csv(st.session_state.uploaded_file)
+        df = df.where(pd.notnull(df), None)
         assert c.TEXT_ORIG_COL in df.columns
         st.session_state.responses_generated_externally = c.TEXT_GENERATED_COL in df.columns
         initialise_session_from_uploaded_file(df)


### PR DESCRIPTION
By default, pd.read_csv parses empty values as NaN. However, Jinja does not interpret NaN as null which stops some expressions from working, e.g. fallback values `value or 0`.
